### PR TITLE
add codecov configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,16 @@
+coverage:
+  status:
+    project:
+      default:
+        # this will change as tests are added
+        target: 50%
+        threshold: 5%
+  notify:
+    slack:
+      default:
+        url: "secret:hM7+uktUBfU5KiJh4dL7Pw9abGO6+7AAUTf8WMVwV4dkM7tSfNO5eNmrw1gd27IHr7SIVtf3ShJ9hsAJJ+1sdqlt5TUyRJ27um3X8ZRzP2yf5NAJoWeIG35/Y7+/jY+bPOqhNiFgVfZt/TIgSq0ioFCISHD6TRkIzlr/EjohC1o="
+        threshold: 5%
+        only_pulls: false
+        branches: null
+        flags: null
+        paths: null


### PR DESCRIPTION
Adding a pretty basic configuration to 

1. Receive Slack notifications instead of emails
2. Require a target code coverage for allowing merges (at least I think that's how it works).

This can change over time but their [defaults](https://docs.codecov.io/docs/codecov-yaml#section-default-yaml) are pretty good for the time being.